### PR TITLE
Remove superfluous check: filecontent.length can never be < 0

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -27,10 +27,6 @@ s_string read_file(s_string filename) {
     fstat(fd, &s);
     filecontent.length = (size_t)s.st_size;
 
-    if(filecontent.length < 0) {
-        message_log("Error while getting filesize", ERR);
-    }
-
     filecontent.position = mmap(NULL, filecontent.length, PROT_READ, MAP_SHARED, fd, 0);
 
     if(filecontent.position < 0) {


### PR DESCRIPTION
Hi @Glorf! I came across LEAR on the Hacker News front page — cool project!

I added it to [LGTM.com](https://lgtm.com/projects/g/Glorf/lear/alerts/) to analyse your source code; turns out your code is really clean. It only flagged up [one tiny alert](https://lgtm.com/projects/g/Glorf/lear/snapshot/bd37fd53a6954ba782d43bb6c1691ea560a649e9/files/cache.c#xe4f28d6cbdb423d4:1): a superfluous negative check on `filecontent.length` in `cache.c`. That's not needed: `length` is an `unsigned long`, so will never be smaller than zero.

If you like you can enable LGTM's automated code review for pull requests: it'll make sure that tiny mistakes (and large security vulnerabilities — [here are some example CVEs](https://lgtm.com/security/disclosures)) never make it into your master branch.

Keep up the good work!

(full disclosure: I'm part of the team that's responsible for LGTM.com :slightly_smiling_face:)