### PR TITLE
Setup CI, add badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ dist: xenial  # required for cmake v3.12
 script:
   - cmake .
   - make install
+  - echo TODO Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 
+dist: xenial  # required for cmake v3.12
+
 script:
   - cmake .
   - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: c
+
+script:
+  - cmake .
+  - make install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # LEAR - Linux Engine for Asset Retrieval
+
+[![Build Status](https://travis-ci.com/anishkny/lear.svg?branch=master)](https://travis-ci.com/anishkny/lear)
+
 ## Description
 LEAR is a simple HTTP server designed to be as simple and fast as possible to achieve one task:
 serve static resources with amazing efficiency. Currently the project is in its early stage,

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ as possible.
 - [ ] Make it able to munmap cache unused for long time
 - [ ] Finish socket dropping implementation
 - [ ] Add automated tests
-- [ ] Setup CI (e.g. TravisCI)
+- [X] Setup CI (e.g. TravisCI)
 
 ## License
 LEAR is distributed for free as a source code, under permissive MIT license


### PR DESCRIPTION
TravisCI build is working on my fork: [![Build Status](https://travis-ci.com/anishkny/lear.svg?branch=master)](https://travis-ci.com/anishkny/lear)

You would need to setup Travis under your org `Glorf` and update the README build badge accordingly.

Also, there are some [warnings](https://travis-ci.com/anishkny/lear/builds/95277298#L480) but `make install` passes. Not sure if relevant.